### PR TITLE
Use of a temporary hash for the ColumnInfo constructor to avoid a thrown...

### DIFF
--- a/lib/dbi/columninfo.rb
+++ b/lib/dbi/columninfo.rb
@@ -37,6 +37,7 @@ module DBI
         def initialize(hash=nil)
             @hash = hash.dup rescue nil
             @hash ||= Hash.new
+            h = {}
 
             # coerce all strings to symbols
             @hash.each_key do |x|
@@ -46,11 +47,12 @@ module DBI
                         raise ::TypeError, 
                             "#{self.class.name} may construct from a hash keyed with strings or symbols, but not both" 
                     end
-                    @hash[sym] = @hash[x]
+                    h[sym] = @hash[x]
                     @hash.delete(x)
                 end
             end
 
+            @hash = h
             super(@hash)
         end
 


### PR DESCRIPTION
... exception when calling column_info on a DBI statement handler.
https://github.com/erikh/ruby-dbi/blob/master/lib/dbi/handles/statement.rb#L183

https://github.com/jruby/jruby/blob/master/src/org/jruby/RubyHash.java#L463

jruby version : 1.6.5.1 (ruby-1.8.7-p330) (2011-12-27 1bf37c2) (OpenJDK Client VM 1.6.0_20) [linux-i386-java]
