### PR TITLE
fix row#dup method for ruby > 1.9

### DIFF
--- a/lib/dbi/row.rb
+++ b/lib/dbi/row.rb
@@ -235,7 +235,7 @@ module DBI
                 row.instance_variable_set :@column_names,  @column_names
                 # this is the only one we actually dup...
                 row.instance_variable_set :@arr,           arr = @arr.dup
-                row.instance_variable_set :@_dc_obj,       arr
+                row.instance_variable_set :@delegate_dc_obj,       arr
                 row
             end
         end


### PR DESCRIPTION
Fix issue with call to methods delegated to Array after a call to row#dup.
Ensure that instance variable from DelegateClass is set too.