### PR TITLE
modified line 212 of row.rb in order to work with Ruby versions 2+

### DIFF
--- a/lib/dbi/row.rb
+++ b/lib/dbi/row.rb
@@ -209,7 +209,7 @@ module DBI
         end
 
 
-        if RUBY_VERSION =~ /^1\.9/
+        if RUBY_VERSION =~ /^1\.9/ || RUBY_VERSION =~ /^2/
             def __getobj__
                 @arr
             end


### PR DESCRIPTION
Hi Erik,
Is there anyway to get this little change merged up? By allowing rubi_dbi to work with more recent versions of Ruby will help me not have to hack the gem to make it work, which it does quite well with Ruby 2.x (I've verified using DB2 and SQL server on Ruby 2.1.6 and 2.3.3).

Thanks,
Randy