### PR TITLE
Update_to_types.rb

### DIFF
--- a/lib/dbi/types.rb
+++ b/lib/dbi/types.rb
@@ -95,7 +95,7 @@ module DBI
         #
         class Decimal < Float
             def self.parse(obj)
-                BigDecimal.new(obj) rescue super
+                BigDecimal(obj) rescue super
             end
         end
 


### PR DESCRIPTION
removed the ".new" that followed BigDecimal because within Ruby 2.6.5 it gives Deprecation Warnings.